### PR TITLE
fix: 优化字体大小处理，添加范围限制和对应字体样式

### DIFF
--- a/Sources/BBCode/Renders/Text.swift
+++ b/Sources/BBCode/Renders/Text.swift
@@ -584,26 +584,39 @@ var textRenders: [BBType: TextRender] {
       if n.attr.isEmpty {
         return n.renderInnerText(args)
       }
-      guard var size = Int(n.attr) else {
+      guard let size = Int(n.attr) else {
         return n.renderInnerText(args)
       }
-      if size < 8 {
-        size = 8
-      }
-      if size > 50 {
-        size = 50
+      let font: Font
+      switch size {
+      case 1:
+        font = .footnote
+      case 2:
+        font = .body
+      case 3:
+        font = .subheadline
+      case 4:
+        font = .headline
+      case 5:
+        font = .title3
+      case 6:
+        font = .title
+      case 7:
+        font = .largeTitle
+      default:
+        font = .system(size: CGFloat(min(max(size, 8), 50)))
       }
       switch n.renderInnerText(args) {
       case .string(var content):
         // FIXME: preserve inner font style
-        content.font = .system(size: CGFloat(size))
+        content.font = font
         return .string(content)
       case .text(let content):
-        return .text(content.font(.system(size: CGFloat(size))))
+        return .text(content.font(font))
       case .view(let content):
         return .view(
           AnyView(
-            content.font(.system(size: CGFloat(size)))
+            content.font(font)
           )
         )
       }


### PR DESCRIPTION
bbcode似乎没有一个准确的标准处理size，我看到下面几种标准
1. 7个固定尺寸：1<=size<=7，默认字号为2:，**这部分也是本次pr提交的部分**
2. 带指像素大小：有部分会加上`px`表述，例如`[size=20px]`（也是原本的处理逻辑，并且使用`.clamped`方法表达钳位，提高表达能力）
3. 百分比缩放，以100为标准进行缩放，50<=size<=200，`[size=100]`表示默认字号，50表示为默认字号的一半大小，200表示为2倍高度（未实现，后续可以继续补充）