### PR TITLE
feat: 支持 size 标签中 1-7 7种字体大小的选择

### DIFF
--- a/Sources/BBCode/Renders/HTML.swift
+++ b/Sources/BBCode/Renders/HTML.swift
@@ -324,7 +324,8 @@ var htmlRenders: [BBType: HTMLRender] {
           valid = true
         }
         if valid {
-          html = "<span style=\"font-size: \(n.attr)px\">\(n.renderInnerHTML(args))</span>"
+          html =
+            "<span style=\"font-size: \(getFontSizeString(size: size!));\">\(n.renderInnerHTML(args))</span>"
         } else {
           html = "[size=\(n.escapedAttr)]\(n.renderInnerHTML(args))[/size]"
         }
@@ -400,6 +401,27 @@ var htmlRenders: [BBType: HTMLRender] {
       return "<span class=\"bmo-emoji\" data-code=\"\(bmoCode)\">(\(bmoCode))</span>"
     },
   ]
+}
+
+func getFontSizeString(size: Int) -> String {
+  switch size {
+  case 1:
+    return "x-small"
+  case 2:
+    return "small"
+  case 3:
+    return "medium"
+  case 4:
+    return "large"
+  case 5:
+    return "x-large"
+  case 6:
+    return "xx-large"
+  case 7:
+    return "xxx-large"
+  default:
+    return "\(size)px"
+  }
 }
 
 func BBCodeToHTML(code: String, textSize: Int) -> String {

--- a/Sources/BBCode/Renders/Text.swift
+++ b/Sources/BBCode/Renders/Text.swift
@@ -584,26 +584,39 @@ var textRenders: [BBType: TextRender] {
       if n.attr.isEmpty {
         return n.renderInnerText(args)
       }
-      guard var size = Int(n.attr) else {
+      guard let size = Int(n.attr) else {
         return n.renderInnerText(args)
       }
-      if size < 8 {
-        size = 8
-      }
-      if size > 50 {
-        size = 50
+      let font: Font
+      switch size {
+      case 1:
+        font = .footnote
+      case 2:
+        font = .body
+      case 3:
+        font = .subheadline
+      case 4:
+        font = .headline
+      case 5:
+        font = .title3
+      case 6:
+        font = .title
+      case 7:
+        font = .largeTitle
+      default:
+        font = .system(size: CGFloat(min(max(size, 8), 50)))
       }
       switch n.renderInnerText(args) {
       case .string(var content):
         // FIXME: preserve inner font style
-        content.font = .system(size: CGFloat(size))
+        content.font = font
         return .string(content)
       case .text(let content):
-        return .text(content.font(.system(size: CGFloat(size))))
+        return .text(content.font(font))
       case .view(let content):
         return .view(
           AnyView(
-            content.font(.system(size: CGFloat(size)))
+            content.font(font)
           )
         )
       }

--- a/Sources/BBCode/Renders/Text.swift
+++ b/Sources/BBCode/Renders/Text.swift
@@ -590,15 +590,15 @@ var textRenders: [BBType: TextRender] {
       let font: Font
       switch size {
       case 1:
-        font = .footnote
+        font = .caption
       case 2:
-        font = .body
+        font = .footnote
       case 3:
-        font = .subheadline
+        font = .body
       case 4:
-        font = .headline
+        font = .subheadline
       case 5:
-        font = .title3
+        font = .headline
       case 6:
         font = .title
       case 7:

--- a/Tests/BBCodeTests/HTMLTests.swift
+++ b/Tests/BBCodeTests/HTMLTests.swift
@@ -65,7 +65,7 @@ class HTMLTests: XCTestCase {
   func testSize() {
     XCTAssertEqual(
       try BBCode().html("[size=10]不同[/size][size=14]大小的[/size][size=18]文字[/size]效果也可实现"),
-      "<span style=\"font-size: 10px\">不同</span><span style=\"font-size: 14px\">大小的</span><span style=\"font-size: 18px\">文字</span>效果也可实现"
+      "<span style=\"font-size: 10px;\">不同</span><span style=\"font-size: 14px;\">大小的</span><span style=\"font-size: 18px;\">文字</span>效果也可实现"
     )
   }
 

--- a/Tests/BBCodeTests/HTMLTests.swift
+++ b/Tests/BBCodeTests/HTMLTests.swift
@@ -64,8 +64,9 @@ class HTMLTests: XCTestCase {
 
   func testSize() {
     XCTAssertEqual(
-      try BBCode().html("[size=10]不同[/size][size=14]大小的[/size][size=18]文字[/size]效果也可实现"),
-      "<span style=\"font-size: 10px;\">不同</span><span style=\"font-size: 14px;\">大小的</span><span style=\"font-size: 18px;\">文字</span>效果也可实现"
+      try BBCode().html(
+        "[size=10]不同[/size][size=14]大小的[/size][size=18]文字[/size]效果[size=6]也可实现[/size]"),
+      "<span style=\"font-size: 10px;\">不同</span><span style=\"font-size: 14px;\">大小的</span><span style=\"font-size: 18px;\">文字</span>效果<span style=\"font-size: xx-large;\">也可实现</span>"
     )
   }
 


### PR DESCRIPTION
bbcode似乎没有一个准确的标准处理size，我看到下面几种标准
1. 7个固定尺寸：1<=size<=7，默认字号为3:，**这部分也是本次pr提交的部分**
2. 带指像素大小：有部分会加上`px`表述，例如`[size=20px]`（也是原本的处理逻辑）
3. 百分比缩放，以100为标准进行缩放，50<=size<=200，`[size=100]`表示默认字号，50表示为默认字号的一半大小，200表示为2倍高度（未实现，后续可以继续补充）